### PR TITLE
Generate fake transaction and user activity data

### DIFF
--- a/kafka_faker/__init__.py
+++ b/kafka_faker/__init__.py
@@ -1,0 +1,27 @@
+"""Utilities for generating fake Kafka events and producing them.
+
+Modules:
+- transactions: transaction generator functions
+- user_activity: user activity generator functions
+- producer: Kafka/Stdout sinks
+- cli: command-line entrypoint
+"""
+from .transactions import (
+    generate_transaction,
+    iter_transactions,
+    generate_random_user_ids,
+)
+from .user_activity import generate_user_activity, iter_user_activity
+from .producer import OutputSink, StdoutSink, KafkaSink, KafkaJsonProducer
+
+__all__ = [
+    "generate_transaction",
+    "iter_transactions",
+    "generate_random_user_ids",
+    "generate_user_activity",
+    "iter_user_activity",
+    "OutputSink",
+    "StdoutSink",
+    "KafkaSink",
+    "KafkaJsonProducer",
+]

--- a/kafka_faker/cli.py
+++ b/kafka_faker/cli.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Iterable, List, Optional
+
+from .producer import KafkaJsonProducer, KafkaSink, StdoutSink
+from .transactions import iter_transactions, generate_random_user_ids
+from .user_activity import iter_user_activity
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Emit fake events to Kafka or stdout."
+    )
+
+    parser.add_argument(
+        "--sink",
+        choices=["stdout", "kafka"],
+        default="stdout",
+        help="Where to send events.",
+    )
+    parser.add_argument(
+        "--bootstrap-servers",
+        default="localhost:9092",
+        help="Kafka bootstrap servers (host:port)",
+    )
+    parser.add_argument(
+        "--topic",
+        required=True,
+        choices=["transactions", "user_activity"],
+        help="Kafka topic to emit to.",
+    )
+    parser.add_argument(
+        "--rate",
+        type=float,
+        default=0.0,
+        help="Messages per second (approx). 0 means as fast as possible.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Total number of messages to send (0 = unlimited).",
+    )
+    parser.add_argument(
+        "--users",
+        type=int,
+        default=100,
+        help="Size of user id pool to sample from.",
+    )
+
+    return parser
+
+
+def _choose_generator(topic: str, user_pool: List[str]):
+    if topic == "transactions":
+        return iter_transactions(user_id_pool=user_pool)
+    if topic == "user_activity":
+        return iter_user_activity(user_id_pool=user_pool)
+    raise ValueError(f"Unsupported topic: {topic}")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.sink == "kafka":
+        sink = KafkaSink(args.bootstrap_servers)
+    else:
+        sink = StdoutSink()
+
+    sleep_seconds = 0.0
+    if args.rate and args.rate > 0:
+        sleep_seconds = 1.0 / float(args.rate)
+
+    limit = None if args.limit == 0 else int(args.limit)
+
+    user_pool = generate_random_user_ids(max(1, int(args.users)))
+
+    generator = _choose_generator(args.topic, user_pool)
+
+    producer = KafkaJsonProducer(sink=sink, sleep_seconds_between_messages=sleep_seconds)
+    sent = producer.run(args.topic, generator, limit=limit)
+
+    return 0 if sent or limit == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kafka_faker/producer.py
+++ b/kafka_faker/producer.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, Optional
+
+try:
+    from kafka import KafkaProducer  # type: ignore
+except Exception:  # pragma: no cover - library may not be installed yet
+    KafkaProducer = None  # type: ignore
+
+
+Record = Dict[str, object]
+
+
+@dataclass
+class OutputSink:
+    def send(self, topic: str, record: Record) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+@dataclass
+class StdoutSink(OutputSink):
+    def send(self, topic: str, record: Record) -> None:
+        line = json.dumps({"topic": topic, "value": record}, separators=(",", ":"))
+        print(line, flush=True)
+
+
+@dataclass
+class KafkaSink(OutputSink):
+    bootstrap_servers: str
+    acks: str = "1"
+    linger_ms: int = 20
+    _producer: Optional[KafkaProducer] = None
+
+    def _get_producer(self) -> KafkaProducer:
+        if KafkaProducer is None:
+            raise RuntimeError(
+                "kafka-python is not installed. Install dependencies from requirements.txt"
+            )
+        if self._producer is None:
+            self._producer = KafkaProducer(
+                bootstrap_servers=self.bootstrap_servers,
+                acks=self.acks,
+                linger_ms=self.linger_ms,
+                value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+                key_serializer=lambda k: (k or "").encode("utf-8"),
+            )
+        return self._producer
+
+    def send(self, topic: str, record: Record) -> None:
+        producer = self._get_producer()
+        producer.send(topic, value=record)
+
+
+@dataclass
+class KafkaJsonProducer:
+    sink: OutputSink
+    sleep_seconds_between_messages: float = 0.0
+
+    def run(self, topic: str, generator: Iterable[Record], limit: Optional[int] = None) -> int:
+        sent = 0
+        for record in generator:
+            self.sink.send(topic, record)
+            sent += 1
+            if limit is not None and sent >= limit:
+                break
+            if self.sleep_seconds_between_messages > 0:
+                time.sleep(self.sleep_seconds_between_messages)
+        return sent

--- a/kafka_faker/transactions.py
+++ b/kafka_faker/transactions.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import random
+from datetime import datetime, timezone
+from typing import Dict, Iterator, List, Optional, Sequence
+from uuid import uuid4
+
+MERCHANTS: List[str] = [
+    "Amazon",
+    "Walmart",
+    "Target",
+    "Starbucks",
+    "Apple",
+    "Best Buy",
+    "Costco",
+    "Uber",
+    "Lyft",
+    "Netflix",
+    "Spotify",
+    "Airbnb",
+    "Expedia",
+    "McDonald's",
+    "Shell",
+    "Chevron",
+    "BP",
+    "Home Depot",
+    "Lowe's",
+    "IKEA",
+    "eBay",
+    "AliExpress",
+    "DoorDash",
+    "Grubhub",
+    "Sephora",
+]
+
+
+def _choose_amount_usd() -> float:
+    """Generate a realistic USD amount with a heavy tail.
+
+    Most transactions are small; a few are very large.
+    """
+    band = random.choices(
+        ["small", "medium", "large", "xl"], weights=[0.65, 0.25, 0.09, 0.01]
+    )[0]
+    if band == "small":
+        amount = random.uniform(1.00, 30.00)
+    elif band == "medium":
+        amount = random.uniform(30.00, 150.00)
+    elif band == "large":
+        amount = random.uniform(150.00, 1000.00)
+    else:  # xl
+        amount = random.uniform(1000.00, 5000.00)
+    return round(amount, 2)
+
+
+def _fraud_probability_for_amount(amount_usd: float) -> float:
+    base_probability = 0.02
+    if amount_usd >= 1000:
+        return 0.15
+    if amount_usd >= 250:
+        return 0.05
+    return base_probability
+
+
+def generate_random_user_ids(count: int) -> List[str]:
+    if count <= 0:
+        return []
+    return [str(uuid4()) for _ in range(count)]
+
+
+def generate_transaction(
+    *,
+    user_id: Optional[str] = None,
+    user_id_pool: Optional[Sequence[str]] = None,
+    timestamp: Optional[datetime] = None,
+) -> Dict[str, object]:
+    """Create a single transaction record matching the schema.
+
+    Schema:
+        {
+          "transaction_id": "uuid",
+          "user_id": "uuid",
+          "amount": float,
+          "merchant": "str",
+          "currency": "USD",
+          "timestamp": "ISO8601",
+          "is_fraud": bool
+        }
+    """
+    if user_id is None:
+        if user_id_pool:
+            user_id = random.choice(list(user_id_pool))
+        else:
+            user_id = str(uuid4())
+
+    event_time = timestamp or datetime.now(timezone.utc)
+    amount = _choose_amount_usd()
+    fraud_probability = _fraud_probability_for_amount(amount)
+
+    record: Dict[str, object] = {
+        "transaction_id": str(uuid4()),
+        "user_id": user_id,
+        "amount": amount,
+        "merchant": random.choice(MERCHANTS),
+        "currency": "USD",
+        "timestamp": event_time.isoformat(timespec="seconds"),
+        "is_fraud": random.random() < fraud_probability,
+    }
+    return record
+
+
+def iter_transactions(
+    *, count: Optional[int] = None, user_id_pool: Optional[Sequence[str]] = None
+) -> Iterator[Dict[str, object]]:
+    """Yield transaction records.
+
+    If count is None, generate indefinitely.
+    """
+    emitted = 0
+    while count is None or emitted < count:
+        yield generate_transaction(user_id_pool=user_id_pool)
+        emitted += 1

--- a/kafka_faker/user_activity.py
+++ b/kafka_faker/user_activity.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import random
+from datetime import datetime, timezone
+from typing import Dict, Iterator, List, Optional, Sequence
+from uuid import uuid4
+
+EVENT_TYPES: List[str] = ["click", "view", "add_to_cart", "purchase"]
+EVENT_TYPE_WEIGHTS: List[float] = [0.30, 0.50, 0.15, 0.05]
+
+DEVICES: List[str] = ["mobile", "desktop", "tablet"]
+DEVICE_WEIGHTS: List[float] = [0.6, 0.3, 0.1]
+
+BROWSERS: List[str] = ["Chrome", "Safari", "Firefox", "Edge"]
+BROWSER_WEIGHTS: List[float] = [0.6, 0.2, 0.15, 0.05]
+
+
+def generate_user_activity(
+    *,
+    user_id: Optional[str] = None,
+    user_id_pool: Optional[Sequence[str]] = None,
+    event_type: Optional[str] = None,
+    timestamp: Optional[datetime] = None,
+) -> Dict[str, object]:
+    """Create a single user activity record matching the schema.
+
+    Schema:
+        {
+          "event_id": "uuid",
+          "user_id": "uuid",
+          "event_type": "click|view|add_to_cart|purchase",
+          "device": "mobile|desktop|tablet",
+          "browser": "Chrome|Safari|Firefox|Edge",
+          "timestamp": "ISO8601"
+        }
+    """
+    if user_id is None:
+        if user_id_pool:
+            user_id = random.choice(list(user_id_pool))
+        else:
+            user_id = str(uuid4())
+
+    if event_type is None:
+        event_type = random.choices(EVENT_TYPES, weights=EVENT_TYPE_WEIGHTS, k=1)[0]
+
+    event_time = timestamp or datetime.now(timezone.utc)
+
+    record: Dict[str, object] = {
+        "event_id": str(uuid4()),
+        "user_id": user_id,
+        "event_type": event_type,
+        "device": random.choices(DEVICES, weights=DEVICE_WEIGHTS, k=1)[0],
+        "browser": random.choices(BROWSERS, weights=BROWSER_WEIGHTS, k=1)[0],
+        "timestamp": event_time.isoformat(timespec="seconds"),
+    }
+    return record
+
+
+def iter_user_activity(
+    *, count: Optional[int] = None, user_id_pool: Optional[Sequence[str]] = None
+) -> Iterator[Dict[str, object]]:
+    """Yield user activity records.
+
+    If count is None, generate indefinitely.
+    """
+    emitted = 0
+    while count is None or emitted < count:
+        yield generate_user_activity(user_id_pool=user_id_pool)
+        emitted += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+faker==25.0.0
+kafka-python==2.0.2
+python-dateutil==2.9.0.post0


### PR DESCRIPTION
Add a Python data generator with a CLI to produce fake `transactions` and `user_activity` data to Kafka topics or stdout.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ea91922-d40d-47a6-bd45-b670cdb37c5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ea91922-d40d-47a6-bd45-b670cdb37c5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

